### PR TITLE
Disable analysis.FixEmptyResponseDescriptions in mixin command

### DIFF
--- a/cmd/swagger/commands/mixin.go
+++ b/cmd/swagger/commands/mixin.go
@@ -111,7 +111,7 @@ func (c *MixinSpec) MixinFiles(primaryFile string, mixinFiles []string, w io.Wri
 	}
 
 	collisions := analysis.Mixin(primary, mixins...)
-	analysis.FixEmptyResponseDescriptions(primary)
+	// analysis.FixEmptyResponseDescriptions(primary)
 
 	return collisions, writeToFile(primary, !c.Compact, c.Format, string(c.Output))
 }


### PR DESCRIPTION
This was causing nil pointer access on some schemas (presumably, because they were lacking responses, but that's indended in our case, as we're using "pseudo-methods")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/go-swagger/5)
<!-- Reviewable:end -->
